### PR TITLE
Add undocumented measurement types, support for segmented values

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,9 +74,3 @@ jobs:
           poetry run coverage xml -i
       - name: 🚀 Upload coverage report
         uses: codecov/codecov-action@v3.1.4
-      - name: SonarCloud Scan
-        if: github.event.pull_request.head.repo.fork == false
-        uses: SonarSource/sonarcloud-github-action@v2.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ ignore = [
   "ANN101", # Self... explanatory
   "ANN102", # cls... just as useless
   "ANN401", # Opinioated warning on disallowing dynamically typed expressions
+  "COM812", # Breaks the linting
+  "ISC001", # Breaks the linting
   "D203", # Conflicts with other rules
   "D213", # Conflicts with other rules
   "D417", # False positives in some occasions

--- a/src/aiowithings/models.py
+++ b/src/aiowithings/models.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timezone
 from enum import IntEnum, IntFlag, StrEnum
 from typing import Any, Self
 
-from aiowithings.util import get_measurement_from_dict, to_enum
+from aiowithings.util import get_measurement_from_dict, to_enum, to_enum_or_none
 
 
 class AuthScope(StrEnum):
@@ -170,6 +170,27 @@ class MeasurementAttribution(IntEnum):
     GUIDED_CONDITIONS = 15
 
 
+class MeasurementPosition(IntEnum):
+    """Measure positions."""
+
+    UNKNOWN = -1
+    RIGHT_WRIST = 0
+    LEFT_WRIST = 1
+    RIGHT_ARM = 2
+    LEFT_ARM = 3
+    RIGHT_FOOT = 4
+    LEFT_FOOT = 5
+    BETWEEN_LEGS = 6
+    WHOLE_BODY = 7
+    LEFT_PART_BODY = 8
+    RIGHT_PART_BODY = 9
+    LEFT_LEG = 10
+    RIGHT_LEG = 11
+    TORSO = 12
+    LEFT_HAND = 13
+    RIGHT_HAND = 14
+
+
 class MeasurementGroupCategory(IntEnum):
     """Measure categories."""
 
@@ -250,6 +271,10 @@ class MeasurementType(IntEnum):
     HYDRATION = 77
     BONE_MASS = 88
     PULSE_WAVE_VELOCITY = 91
+    MUSCLE_PERCENT = 93
+    BONE_PERCENT = 92
+    WATER_PERCENT = 95
+    FAT_FREE_PERCENT = 122
     VO2 = 123
     ATRIAL_FIBRILLATION = 130
     QRS_INTERVAL = 135
@@ -264,11 +289,19 @@ class MeasurementType(IntEnum):
     EXTRACELLULAR_WATER = 168
     INTRACELLULAR_WATER = 169
     VISCERAL_FAT = 170
+    FAT_FREE_MASS_FOR_SEGMENTS = 173
     FAT_MASS_FOR_SEGMENTS = 174
     MUSCLE_MASS_FOR_SEGMENTS = 175
+    IMPEDANCE_5KHZ_FOR_SEGMENTS = 176
+    IMPEDANCE_50HZ_FOR_SEGMENTS = 177
+    IMPEDANCE_250HZ_FOR_SEGMENTS = 178
+    IMPEDANCE_625KHZ_FOR_SEGMENTS = 189
     ELECTRODERMAL_ACTIVITY_FEET = 196
     ELECTRODERMAL_ACTIVITY_LEFT_FOOT = 197
     ELECTRODERMAL_ACTIVITY_RIGHT_FOOT = 198
+    BIA_ERROR = 207
+    BASAL_METABOLIC_RATE = 226
+    METABOLIC_AGE = 227
 
 
 @dataclass(slots=True)
@@ -277,17 +310,25 @@ class Measurement:
 
     measurement_type: MeasurementType
     value: float
+    position: MeasurementPosition | None
 
     @classmethod
-    def from_api(cls, measurement: dict[str, Any]) -> Self:
+    def from_api(cls, measurement: dict[str, Any]) -> Measurement:
         """Initialize from the API."""
+        measurement_type = to_enum(
+            MeasurementType,
+            measurement["type"],
+            MeasurementType.UNKNOWN,
+        )
+        value = get_measurement_from_dict(measurement)
+        position = to_enum_or_none(
+            MeasurementPosition,
+            measurement.get("position", None),
+        )
         return cls(
-            measurement_type=to_enum(
-                MeasurementType,
-                measurement["type"],
-                MeasurementType.UNKNOWN,
-            ),
-            value=get_measurement_from_dict(measurement),
+            measurement_type=measurement_type,
+            value=value,
+            position=position,
         )
 
 

--- a/src/aiowithings/util.py
+++ b/src/aiowithings/util.py
@@ -1,21 +1,22 @@
 """Asynchronous Python client for Withings."""
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, TypeVar, cast
 
 from aiowithings.const import LOGGER
 
-_EnumT = TypeVar("_EnumT")
+T = TypeVar("T", bound=Enum)
 
 
 def to_enum(
-    enum_class: type[_EnumT],
+    enum_class: type[T],
     value: Any,
-    default_value: _EnumT,
-) -> _EnumT:
+    default_value: T,
+) -> T:
     """Convert a value to an enum and log if it doesn't exist."""
     try:
-        return enum_class(value)  # type: ignore[call-arg]
+        return enum_class(value)
     except ValueError:
         LOGGER.warning(
             "%s is an unsupported value for %s, please report this at https://github.com/joostlek/python-withings/issues",
@@ -23,6 +24,17 @@ def to_enum(
             str(enum_class),
         )
         return default_value
+
+
+def to_enum_or_none(
+    enum_class: type[T],
+    value: Any,
+) -> T | None:
+    """Convert a value to an enum or None if it fails."""
+    try:
+        return enum_class(value)
+    except ValueError:
+        return None
 
 
 def get_measurement(value: int, unit: int) -> float:

--- a/tests/__snapshots__/test_withings.ambr
+++ b/tests/__snapshots__/test_withings.ambr
@@ -156,6 +156,7 @@
       'measurements': list([
         dict({
           'measurement_type': <MeasurementType.WEIGHT: 1>,
+          'position': None,
           'value': 118.003,
         }),
       ]),
@@ -172,6 +173,7 @@
       'measurements': list([
         dict({
           'measurement_type': <MeasurementType.WEIGHT: 1>,
+          'position': None,
           'value': 118.003,
         }),
       ]),
@@ -192,6 +194,7 @@
       'measurements': list([
         dict({
           'measurement_type': <MeasurementType.WEIGHT: 1>,
+          'position': None,
           'value': 118.003,
         }),
       ]),
@@ -208,6 +211,7 @@
       'measurements': list([
         dict({
           'measurement_type': <MeasurementType.WEIGHT: 1>,
+          'position': None,
           'value': 118.003,
         }),
       ]),


### PR DESCRIPTION
# Proposed Changes

Add models for Position (for segmented measurements) and add on to Measurement some of the undocumented types that are causing errors in Home Assistant component

Ignore the changes I had to make to get some of the tests through, I'm not a python dev.

# Note

I am not typically a github user and I don't really code in Python but I do use this package and I have a Body Scan and I just wanted to add in measurement types that are showing up as errors in the Home Assistant component.  I don't care if you use the PR, but if you want to cherry pick out the values I added to the Measurement and add Position that are missing I just want the component to work without errors again.  I attached a sample API get_measurement response which includes the fields so you can see what they look like.
[withings.json](https://github.com/joostlek/python-withings/files/14076860/withings.json)

I was going to also PR the home assistant component to add some new sensors around this and add support for position, which I did do, but I had enough trouble getting through the python linters and testing on this project with no experience, forget the ones on the HA project, it took me way too long just to add a few enum values so I will leave that as an exercise to an actual Python dev.

## Related Issues

> #157 
> #145 
> #138 
