### PR TITLE
fix(util): log an unsupported enum value once, not on every poll

### DIFF
--- a/src/aiowithings/util.py
+++ b/src/aiowithings/util.py
@@ -6,21 +6,34 @@ from typing import Any, cast
 
 from aiowithings.const import LOGGER
 
+_LOGGED_UNSUPPORTED_VALUES: set[tuple[type[Any], Any]] = set()
+
 
 def to_enum[EnumT](
     enum_class: type[EnumT],
     value: Any,
     default_value: EnumT,
 ) -> EnumT:
-    """Convert a value to an enum and log if it doesn't exist."""
+    """Convert a value to an enum and log if it doesn't exist.
+
+    Logged once per distinct (enum, value) pair for the life of the
+    process, not on every call. A polled account with one unmapped device
+    or attribution otherwise repeats the identical warning on every poll --
+    reported as 1,250 occurrences in 5 days for a single undocumented
+    value (joostlek/python-withings#86). The API returns a small, bounded
+    set of distinct codes, so this does not grow unbounded in practice.
+    """
     try:
         return enum_class(value)  # type: ignore[call-arg]
     except ValueError:
-        LOGGER.warning(
-            "%s is an unsupported value for %s, please report this at https://github.com/joostlek/python-withings/issues",
-            value,
-            str(enum_class),
-        )
+        key = (enum_class, value)
+        if key not in _LOGGED_UNSUPPORTED_VALUES:
+            _LOGGED_UNSUPPORTED_VALUES.add(key)
+            LOGGER.warning(
+                "%s is an unsupported value for %s, please report this at https://github.com/joostlek/python-withings/issues",
+                value,
+                str(enum_class),
+            )
         return default_value
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,16 @@
 """Asynchronous Python client for Withings."""
 
-from aiowithings.util import get_measurement, get_measurement_from_dict
+import enum
+import logging
+
+import pytest
+
+from aiowithings.util import (
+    _LOGGED_UNSUPPORTED_VALUES,
+    get_measurement,
+    get_measurement_from_dict,
+    to_enum,
+)
 
 
 def test_measurement() -> None:
@@ -11,3 +21,87 @@ def test_measurement() -> None:
 def test_measurement_from_dict() -> None:
     """Test measurement."""
     assert get_measurement_from_dict({"value": 20, "unit": -1}) == 2
+
+
+class _Color(enum.IntEnum):
+    """A throwaway enum, isolated from the library's real ones.
+
+    Reusing a real enum (e.g. DeviceModel) would share the module-level
+    dedup set across tests and across the library's own real usage,
+    exactly the "shared mutable fixture" bug the project's own contribution
+    notes warn about (a fixture/state one test populates silently changes
+    the result of another).
+    """
+
+    RED = 1
+    GREEN = 2
+
+
+@pytest.fixture(autouse=True)
+def _reset_logged_unsupported_values() -> None:
+    """Clear the module-level dedup state before every test in this file."""
+    _LOGGED_UNSUPPORTED_VALUES.clear()
+
+
+def test_to_enum_returns_the_matching_member() -> None:
+    """The common case: the value is a real member."""
+    assert to_enum(_Color, 1, _Color.RED) == _Color.RED
+
+
+def test_to_enum_falls_back_and_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    """An unsupported value degrades to the default and is reported once."""
+    with caplog.at_level(logging.WARNING):
+        result = to_enum(_Color, 99, _Color.RED)
+
+    assert result == _Color.RED
+    assert len(caplog.records) == 1
+    assert "99" in caplog.records[0].message
+    assert "_Color" in caplog.records[0].message
+
+
+def test_to_enum_does_not_repeat_the_same_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The motivating case: a polled attribute stays broken between polls.
+
+    Before this, every poll of an account with one unmapped device or
+    attribution logged the same warning again -- one user reported it
+    1,250 times in 5 days for a single undocumented value.
+    """
+    with caplog.at_level(logging.WARNING):
+        first = to_enum(_Color, 99, _Color.RED)
+        second = to_enum(_Color, 99, _Color.RED)
+        third = to_enum(_Color, 99, _Color.RED)
+
+    assert first == second == third == _Color.RED
+    assert len(caplog.records) == 1
+
+
+def test_to_enum_still_warns_for_a_different_unsupported_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dedup is per-value, not "this enum already had a failure"."""
+    with caplog.at_level(logging.WARNING):
+        to_enum(_Color, 99, _Color.RED)
+        to_enum(_Color, 100, _Color.RED)
+
+    assert len(caplog.records) == 2
+
+
+def test_to_enum_still_warns_for_a_different_enum_with_the_same_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dedup keys on (enum_class, value), not on value alone.
+
+    Two unrelated enums can coincidentally share an undocumented numeric
+    value; the second one failing is real information, not a repeat.
+    """
+
+    class _Shape(enum.IntEnum):
+        CIRCLE = 1
+
+    with caplog.at_level(logging.WARNING):
+        to_enum(_Color, 99, _Color.RED)
+        to_enum(_Shape, 99, _Shape.CIRCLE)
+
+    assert len(caplog.records) == 2


### PR DESCRIPTION
Addresses the log-spam half of #86.

## The problem

`to_enum` warns every time it sees a value none of `DeviceModel`,
`MeasurementAttribution`, `WorkoutCategory`, etc. can parse — correctly,
since falling back to a default is the right behaviour. On a polled account
with one unmapped device or attribution, that means the identical warning
on every single poll. From #86: `rahe71` reported **1,250 occurrences in
5 days** for one undocumented `MeasurementAttribution` value.

## What I checked before proposing this

#86 already has a suggested fix in a comment (`UNNAMED_MA_10 = 10`, a
placeholder name for the unmapped value). I read the full thread first
rather than take that at face value, and it goes against a stance you've
stated repeatedly across three years there: you keep asking what the value
*actually* means, and once emailed Withings directly rather than guess —
> I need to know what 10 means, but they don't update their docs on time.

So I haven't touched the enum itself, and this doesn't require knowing what
any of these undocumented values mean. What's independently fixable is the
repetition: `to_enum` now logs a given `(enum_class, value)` pair once for
the life of the process and silences the repeats, letting the first
occurrence through so it's still there for diagnostics/bug reports.

## Validation

- New tests in `tests/test_util.py` assert the count of warning records via
  `caplog`, not just that the call doesn't raise: first occurrence warns,
  repeats of the same value don't, a different value still warns, and a
  different enum class sharing the same numeric value still warns (dedup
  keys on `(enum_class, value)`, not on the value alone).
- Checked each assertion is load-bearing by reverting the fix: only
  `test_to_enum_does_not_repeat_the_same_warning` fails against the
  previous version of `to_enum`, the rest still pass.
- Tests use a private, throwaway `IntEnum` rather than a real one from the
  library, and an autouse fixture clears the module-level dedup set before
  each test — otherwise one test's dedup state could silently change
  another's result, since the set is process-global.
- `uv run pytest --cov src tests`: 65 passed (was 60), **100% coverage**.
- `uv run ruff check` / `ruff format --check`: clean.
- `uv run mypy src tests`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
